### PR TITLE
Add job-specific environment variable support

### DIFF
--- a/orchestrator_service/models.py
+++ b/orchestrator_service/models.py
@@ -18,6 +18,7 @@ class Job:
     pid: Optional[int] = None
     max_tasks: Optional[int] = 50
     error: Optional[Dict[str, Any]] = None
+    env_vars: Dict[str, str] = field(default_factory=dict)
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert job to dictionary for JSON serialization."""


### PR DESCRIPTION
## Summary
- add optional env_vars handling to the job submission and response APIs
- persist env_vars on jobs, propagate them into runner environments, and expose in stored metadata
- extend the fake runner and tests to validate environment variable propagation

## Testing
- pytest orchestrator_service/tests

------
https://chatgpt.com/codex/tasks/task_e_68f305699190832aac2fd9150a4c044f