### PR TITLE
Add environment variable support to job submissions

### DIFF
--- a/visualization/frontend-react/src/__tests__/jobService.test.ts
+++ b/visualization/frontend-react/src/__tests__/jobService.test.ts
@@ -37,6 +37,31 @@ describe('JobService', () => {
       expect(result).toEqual(mockResponse);
     });
 
+    it('should include environment variables when provided', async () => {
+      const mockRequest: SubmitJobRequest = {
+        task_description: 'Test task with env',
+        max_tasks: 5,
+        env_vars: {
+          API_KEY: '12345',
+          EMPTY_VALUE: ''
+        }
+      };
+      const mockResponse = { job_id: 'env-job-123', status: 'QUEUED' };
+
+      vi.mocked(mockApiClient.post).mockResolvedValue(mockResponse);
+
+      await jobService.submitJob(mockRequest);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/jobs', {
+        task_description: 'Test task with env',
+        max_tasks: 5,
+        env_vars: {
+          API_KEY: '12345',
+          EMPTY_VALUE: ''
+        }
+      });
+    });
+
     it('should throw error for empty task description', async () => {
       const mockRequest: SubmitJobRequest = {
         task_description: '',

--- a/visualization/frontend-react/src/components/Jobs/JobDetailPage.tsx
+++ b/visualization/frontend-react/src/components/Jobs/JobDetailPage.tsx
@@ -349,6 +349,32 @@ export const JobDetailPage: React.FC = () => {
                 {job.task_description}
               </Typography>
             </Paper>
+
+            <Paper sx={{ p: 2 }}>
+              <Typography variant="h6" gutterBottom>Environment Variables</Typography>
+              {job.env_vars && Object.keys(job.env_vars).length > 0 ? (
+                <List dense>
+                  {Object.entries(job.env_vars)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([key, value]) => (
+                      <ListItem key={key} disablePadding>
+                        <ListItemText
+                          primary={key}
+                          secondary={value ?? ''}
+                          primaryTypographyProps={{ sx: { fontFamily: 'monospace' } }}
+                          secondaryTypographyProps={{
+                            sx: { fontFamily: 'monospace', whiteSpace: 'pre-wrap' }
+                          }}
+                        />
+                      </ListItem>
+                    ))}
+                </List>
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  No environment variables configured
+                </Typography>
+              )}
+            </Paper>
           </Box>
         </TabPanel>
 
@@ -596,6 +622,7 @@ export const JobDetailPage: React.FC = () => {
             }}
             initialTaskDescription={job?.task_description || ''}
             initialMaxTasks={job?.max_tasks || 50}
+            initialEnvVars={job?.env_vars || null}
           />
         </DialogContent>
       </Dialog>

--- a/visualization/frontend-react/src/services/jobService.ts
+++ b/visualization/frontend-react/src/services/jobService.ts
@@ -31,7 +31,16 @@ export class JobService {
       throw new Error('Task description is required');
     }
 
-    return this.apiClient.post<SubmitJobResponse>('/jobs', data);
+    const payload: SubmitJobRequest = {
+      task_description: data.task_description.trim(),
+      max_tasks: data.max_tasks
+    };
+
+    if (data.env_vars && Object.keys(data.env_vars).length > 0) {
+      payload.env_vars = data.env_vars;
+    }
+
+    return this.apiClient.post<SubmitJobResponse>('/jobs', payload);
   }
 
   /**

--- a/visualization/frontend-react/src/types/jobs.ts
+++ b/visualization/frontend-react/src/types/jobs.ts
@@ -12,11 +12,13 @@ export interface Job {
   trace_files: string[];
   max_tasks?: number;
   error?: Record<string, any> | null;
+  env_vars?: Record<string, string> | null;
 }
 
 export interface SubmitJobRequest {
   task_description: string;
   max_tasks?: number;
+  env_vars?: Record<string, string>;
 }
 
 export interface SubmitJobResponse {


### PR DESCRIPTION
## Summary
- extend job data contracts so environment variables can be supplied when submitting jobs
- enhance the job submission form to accept, validate, and reset KEY=VALUE environment variable input
- surface configured environment variables on the job detail page and reuse them when rerunning a job
- verify the service forwards env vars through a new unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f39487be08832a83a514830caaf28d