### PR TITLE
Auto-enable trace realtime monitoring for running jobs

### DIFF
--- a/visualization/frontend-react/src/components/Jobs/JobDetailPage.tsx
+++ b/visualization/frontend-react/src/components/Jobs/JobDetailPage.tsx
@@ -153,8 +153,11 @@ export const JobDetailPage: React.FC = () => {
 
   const handleTraceClick = (traceFile: string) => {
     // Normalize trace id: backend provides filenames (possibly with .json); viewer expects raw session id
-    const normalized = traceFile.endsWith('.json') ? traceFile.replace(/\.json$/,'') : traceFile;
-    navigate(`/traces?trace=${encodeURIComponent(normalized)}`);
+    const normalized = traceFile.endsWith('.json') ? traceFile.replace(/\.json$/, '') : traceFile;
+
+    navigate(`/traces?trace=${encodeURIComponent(normalized)}`, {
+      state: job.status === 'RUNNING' ? { autoEnableRealtime: true } : undefined,
+    });
   };
 
   const handleDownloadLogs = () => {


### PR DESCRIPTION
## Summary
- pass navigation state when opening a trace from a running job so the trace viewer knows to enable real-time monitoring
- update the trace viewer to consume the navigation hint and start monitoring the selected trace automatically
- extend the job detail trace link test to cover the navigation state behaviour

## Testing
- npm test -- JobDetailTraceLink

------
https://chatgpt.com/codex/tasks/task_e_68f58f119654832a8653d05705c148cd