### PR TITLE
Fix job detail trace navigation when job data missing

### DIFF
--- a/visualization/frontend-react/src/components/Jobs/JobDetailPage.tsx
+++ b/visualization/frontend-react/src/components/Jobs/JobDetailPage.tsx
@@ -156,7 +156,7 @@ export const JobDetailPage: React.FC = () => {
     const normalized = traceFile.endsWith('.json') ? traceFile.replace(/\.json$/, '') : traceFile;
 
     navigate(`/traces?trace=${encodeURIComponent(normalized)}`, {
-      state: job.status === 'RUNNING' ? { autoEnableRealtime: true } : undefined,
+      state: job?.status === 'RUNNING' ? { autoEnableRealtime: true } : undefined,
     });
   };
 


### PR DESCRIPTION
## Summary
- guard the JobDetailPage trace navigation against undefined job data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f78f0dd4c8832a996fd276df034401